### PR TITLE
Add vcpkg as build dependency for 2.16-dev nightlies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - pkg-config  # [not win]
     - {{ compiler('cxx') }}
     - file  # [arm64]
+    - vcpkg
   host:
     - bzip2
     - curl


### PR DESCRIPTION
(testing here before upstream)